### PR TITLE
Merge upstream updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,3 +19,5 @@ Available states
 --------
 
 Installs the GPG key and EPEL RPM package for the current OS.
+
+The EPEL testing repository can be enabled by setting the Pillar ``epel:testing: true``.

--- a/README.rst
+++ b/README.rst
@@ -21,3 +21,5 @@ Available states
 Installs the GPG key and EPEL RPM package for the current OS.
 
 The EPEL testing repository can be enabled by setting the Pillar ``epel:testing: true``.
+
+The EPEL release to be installed can be defind by setting the Pillar ``epel:release: 7-8``

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -16,6 +16,25 @@ epel_release:
     - require:
       - file: install_pubkey_epel
 
+{% if 'repos' in epel %}
+{% for repo, config in epel.repos.items() %}
+config_repo_{{ repo }}:
+  module.run:
+    - name: pkg.mod_repo
+    - repo: {{ repo }}
+    - kwargs:
+{% if config.enabled %}
+        enabled: 1
+{% else %}
+        enabled: 0
+{% endif %}
+        gpgkey: file:///etc/pki/rpm-gpg/{{ epel.key_name }}
+        gpgcheck: 1
+    - require:
+      - pkg: epel_release
+
+{% endfor %}
+{% else %}
 set_pubkey_epel:
   file.replace:
     - append_if_not_found: True
@@ -60,5 +79,6 @@ disable_epel_testing:
     - name: /etc/yum.repos.d/epel-testing.repo
     - pattern: '^\s*enabled=[0,1]'
     - repl: 'enabled=0'
+{% endif %}
 {% endif %}
 {% endif %}

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -18,7 +18,7 @@
   {% set pkg = {
     'key': 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7',
     'key_hash': 'md5=58fa8ae27c89f37b08429f04fd4a88cc',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-' ~ epel_release|default('7-6', true) ~ '.noarch.rpm',
+    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-' ~ epel_release|default('7-7', true) ~ '.noarch.rpm',
   } %}
 {% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] == '2014' %}
   {% set pkg = {

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -2,31 +2,31 @@
 {% if grains['os_family'] == 'RedHat' %}
   {% set epel_release = salt['pillar.get']('epel:release', false) %}
 # A lookup table for EPEL GPG keys & RPM URLs for various RedHat releases
-{% if grains['osmajorrelease'] == 5 %}
+{% if ( grains['saltversion'] >= '2017.7.0' and grains['osmajorrelease'] == 5 ) or ( grains['saltversion'] < '2017.7.0' and grains['osmajorrelease'][0] == '5' ) %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/A4D647E9.txt',
     'key_hash': 'md5=a1d12cd9628338ddb12e9561f9ac1d6a',
     'rpm': 'http://download.fedoraproject.org/pub/epel/5/i386/epel-release-' ~ epel_release|default('5-4', true) ~ '.noarch.rpm',
   } %}
-{% elif grains['osmajorrelease'] == 6 %}
+{% elif ( grains['saltversion'] >= '2017.7.0' and grains['osmajorrelease'] == 6 ) or ( grains['saltversion'] < '2017.7.0' and grains['osmajorrelease'][0] == '6' ) %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/0608B895.txt',
     'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
     'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-' ~ epel_release|default('6-8', true) ~ '.noarch.rpm',
   } %}
-{% elif grains['osmajorrelease'] == 7 %}
+{% elif ( grains['saltversion'] >= '2017.7.0' and grains['osmajorrelease'] == 7 ) or ( grains['saltversion'] < '2017.7.0' and grains['osmajorrelease'][0] == '7' ) %}
   {% set pkg = {
     'key': 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7',
     'key_hash': 'md5=58fa8ae27c89f37b08429f04fd4a88cc',
     'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-' ~ epel_release|default('7-10', true) ~ '.noarch.rpm',
   } %}
-{% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] == '2014' %}
+{% elif grains['os'] == 'Amazon' and ( ( grains['saltversion'] >= '2017.7.0' and grains['osmajorrelease'] == 2014 ) or ( grains['saltversion'] < '2017.7.0' and grains['osmajorrelease'] == '2014' ) ) %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/0608B895.txt',
     'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
     'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-' ~ epel_release|default('6-8', true) ~ '.noarch.rpm',
   } %}
-{% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] == '2015' %}
+{% elif grains['os'] == 'Amazon' and ( ( grains['saltversion'] >= '2017.7.0' and grains['osmajorrelease'] == 2015 ) or ( grains['saltversion'] < '2017.7.0' and grains['osmajorrelease'] == '2015' ) ) %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/0608B895.txt',
     'key_hash': 'md5=eb8749ea67992fd622176442c986b788',

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -9,7 +9,6 @@ install_pubkey_epel:
     - source: {{ epel.key }}
     - source_hash:  {{ epel.key_hash }}
 
-
 epel_release:
   pkg.installed:
     - sources:
@@ -48,5 +47,18 @@ enable_epel:
     - pattern: '^\s*enabled=[0,1]'
     - repl: 'enabled=1'
 {% endif %}
-{% endif %}
 
+{% if epel.testing %}
+enable_epel_testing:
+  file.replace:
+    - name: /etc/yum.repos.d/epel-testing.repo
+    - pattern: '^\s*enabled=[0,1]'
+    - repl: 'enabled=1'
+{% else %}
+disable_epel_testing:
+  file.replace:
+    - name: /etc/yum.repos.d/epel-testing.repo
+    - pattern: '^\s*enabled=[0,1]'
+    - repl: 'enabled=0'
+{% endif %}
+{% endif %}

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -17,8 +17,8 @@
 {% elif grains['osmajorrelease'][0] == '7' %}
   {% set pkg = {
     'key': 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7',
-    'key_hash': 'md5=58fa8ae27c89f37b08429f04fd4a88cc',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-' ~ epel_release|default('7-7', true) ~ '.noarch.rpm',
+    'key_hash': 'md5=2d5d737d69703b926a2275e4c44a65e5',
+    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-' ~ epel_release|default('7-8', true) ~ '.noarch.rpm',
   } %}
 {% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] == '2014' %}
   {% set pkg = {

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -6,7 +6,7 @@
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/A4D647E9.txt',
     'key_hash': 'md5=a1d12cd9628338ddb12e9561f9ac1d6a',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/5/i386/epel-release-' ~ epel_release|default('5-4', true) ~ '.noarch.rpm',
+    'rpm': 'http://download.fedoraproject.org/pub/archive/epel/5/i386/epel-release-' ~ epel_release|default('5-4', true) ~ '.noarch.rpm',
   } %}
 {% elif ( grains['saltversion'] >= '2017.7.0' and grains['osmajorrelease'] == 6 ) or ( grains['saltversion'] < '2017.7.0' and grains['osmajorrelease'][0] == '6' ) %}
   {% set pkg = {

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -18,7 +18,7 @@
   {% set pkg = {
     'key': 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7',
     'key_hash': 'md5=58fa8ae27c89f37b08429f04fd4a88cc',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-' ~ epel_release|default('7-9', true) ~ '.noarch.rpm',
+    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-' ~ epel_release|default('7-10', true) ~ '.noarch.rpm',
   } %}
 {% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] == '2014' %}
   {% set pkg = {

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -18,7 +18,7 @@
   {% set pkg = {
     'key': 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7',
     'key_hash': 'md5=58fa8ae27c89f37b08429f04fd4a88cc',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-' ~ epel_release|default('7-8', true) ~ '.noarch.rpm',
+    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-' ~ epel_release|default('7-9', true) ~ '.noarch.rpm',
   } %}
 {% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] == '2014' %}
   {% set pkg = {

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -28,6 +28,9 @@ config_repo_{{ repo }}:
 {% else %}
         enabled: 0
 {% endif %}
+{% if 'exclude' in config %}
+        exclude: {{ config.exclude|join(',') }}
+{% endif %}
         gpgkey: file:///etc/pki/rpm-gpg/{{ epel.key_name }}
         gpgcheck: 1
     - require:

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -18,7 +18,7 @@
   {% set pkg = {
     'key': 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7',
     'key_hash': 'md5=58fa8ae27c89f37b08429f04fd4a88cc',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm',
+    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm',
   } %}
 {% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] == '2014' %}
   {% set pkg = {

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -1,36 +1,36 @@
 # Completely ignore non-RHEL based systems
 {% if grains['os_family'] == 'RedHat' %}
-
+  {% set epel_release = salt['pillar.get']('epel:release', false) %}
 # A lookup table for EPEL GPG keys & RPM URLs for various RedHat releases
 {% if grains['osmajorrelease'][0] == '5' %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/A4D647E9.txt',
     'key_hash': 'md5=a1d12cd9628338ddb12e9561f9ac1d6a',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/5/i386/epel-release-5-4.noarch.rpm',
+    'rpm': 'http://download.fedoraproject.org/pub/epel/5/i386/epel-release-' ~ epel_release|default('5-4', true) ~ '.noarch.rpm',
   } %}
 {% elif grains['osmajorrelease'][0] == '6' %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/0608B895.txt',
     'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
+    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-' ~ epel_release|default('6-8', true) ~ '.noarch.rpm',
   } %}
 {% elif grains['osmajorrelease'][0] == '7' %}
   {% set pkg = {
     'key': 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7',
     'key_hash': 'md5=58fa8ae27c89f37b08429f04fd4a88cc',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm',
+    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-' ~ epel_release|default('7-6', true) ~ '.noarch.rpm',
   } %}
 {% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] == '2014' %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/0608B895.txt',
     'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
+    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-' ~ epel_release|default('6-8', true) ~ '.noarch.rpm',
   } %}
 {% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] == '2015' %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/0608B895.txt',
     'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
+    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-' ~ epel_release|default('6-8', true) ~ '.noarch.rpm',
   } %}
 {% endif %}
 

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -80,4 +80,18 @@ enable_epel:
     - pattern: '^enabled=[0,1]'
     - repl: 'enabled=1'
 {% endif %}
+
+{% if salt['pillar.get']('epel:testing', False) %}
+enable_epel_testing:
+  file.replace:
+    - name: /etc/yum.repos.d/epel-testing.repo
+    - pattern: '^enabled=[0,1]'
+    - repl: 'enabled=1'
+{% else %}
+disable_epel_testing:
+  file.replace:
+    - name: /etc/yum.repos.d/epel-testing.repo
+    - pattern: '^enabled=[0,1]'
+    - repl: 'enabled=0'
+{% endif %}
 {% endif %}

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -1,51 +1,19 @@
 # Completely ignore non-RHEL based systems
 {% if grains['os_family'] == 'RedHat' %}
-  {% set epel_release = salt['pillar.get']('epel:release', false) %}
-# A lookup table for EPEL GPG keys & RPM URLs for various RedHat releases
-{% if ( grains['saltversion'] >= '2017.7.0' and grains['osmajorrelease'] == 5 ) or ( grains['saltversion'] < '2017.7.0' and grains['osmajorrelease'][0] == '5' ) %}
-  {% set pkg = {
-    'key': 'https://fedoraproject.org/static/A4D647E9.txt',
-    'key_hash': 'md5=a1d12cd9628338ddb12e9561f9ac1d6a',
-    'rpm': 'http://download.fedoraproject.org/pub/archive/epel/5/i386/epel-release-' ~ epel_release|default('5-4', true) ~ '.noarch.rpm',
-  } %}
-{% elif ( grains['saltversion'] >= '2017.7.0' and grains['osmajorrelease'] == 6 ) or ( grains['saltversion'] < '2017.7.0' and grains['osmajorrelease'][0] == '6' ) %}
-  {% set pkg = {
-    'key': 'https://fedoraproject.org/static/0608B895.txt',
-    'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-' ~ epel_release|default('6-8', true) ~ '.noarch.rpm',
-  } %}
-{% elif ( grains['saltversion'] >= '2017.7.0' and grains['osmajorrelease'] == 7 ) or ( grains['saltversion'] < '2017.7.0' and grains['osmajorrelease'][0] == '7' ) %}
-  {% set pkg = {
-    'key': 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7',
-    'key_hash': 'md5=58fa8ae27c89f37b08429f04fd4a88cc',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-' ~ epel_release|default('7-11', true) ~ '.noarch.rpm',
-  } %}
-{% elif grains['os'] == 'Amazon' and ( ( grains['saltversion'] >= '2017.7.0' and grains['osmajorrelease'] == 2014 ) or ( grains['saltversion'] < '2017.7.0' and grains['osmajorrelease'] == '2014' ) ) %}
-  {% set pkg = {
-    'key': 'https://fedoraproject.org/static/0608B895.txt',
-    'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-' ~ epel_release|default('6-8', true) ~ '.noarch.rpm',
-  } %}
-{% elif grains['os'] == 'Amazon' and ( ( grains['saltversion'] >= '2017.7.0' and grains['osmajorrelease'] == 2015 ) or ( grains['saltversion'] < '2017.7.0' and grains['osmajorrelease'] == '2015' ) ) %}
-  {% set pkg = {
-    'key': 'https://fedoraproject.org/static/0608B895.txt',
-    'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-' ~ epel_release|default('6-8', true) ~ '.noarch.rpm',
-  } %}
-{% endif %}
 
+{% from "epel/map.jinja" import epel with context %}
 
 install_pubkey_epel:
   file.managed:
-    - name: /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL
-    - source: {{ salt['pillar.get']('epel:pubkey', pkg.key) }}
-    - source_hash:  {{ salt['pillar.get']('epel:pubkey_hash', pkg.key_hash) }}
+    - name: /etc/pki/rpm-gpg/{{ epel.key_name }}
+    - source: {{ epel.key }}
+    - source_hash:  {{ epel.key_hash }}
 
 
 epel_release:
   pkg.installed:
     - sources:
-      - epel-release: {{ salt['pillar.get']('epel:rpm', pkg.rpm) }}
+      - epel-release: {{ epel.rpm }}
     - require:
       - file: install_pubkey_epel
 
@@ -53,8 +21,8 @@ set_pubkey_epel:
   file.replace:
     - append_if_not_found: True
     - name: /etc/yum.repos.d/epel.repo
-    - pattern: '^gpgkey=.*'
-    - repl: 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL'
+    - pattern: '^\s*gpgkey=.*'
+    - repl: 'gpgkey=file:///etc/pki/rpm-gpg/{{ epel.key_name }}'
     - require:
       - pkg: epel_release
 
@@ -62,36 +30,23 @@ set_gpg_epel:
   file.replace:
     - append_if_not_found: True
     - name: /etc/yum.repos.d/epel.repo
-    - pattern: 'gpgcheck=.*'
+    - pattern: '^\s*gpgcheck=.*'
     - repl: 'gpgcheck=1'
     - require:
       - pkg: epel_release
 
-{% if salt['pillar.get']('epel:disabled', False) %}
+{% if epel.disabled %}
 disable_epel:
   file.replace:
     - name: /etc/yum.repos.d/epel.repo
-    - pattern: '^enabled=[0,1]'
+    - pattern: '^\s*enabled=[0,1]'
     - repl: 'enabled=0'
 {% else %}
 enable_epel:
   file.replace:
     - name: /etc/yum.repos.d/epel.repo
-    - pattern: '^enabled=[0,1]'
+    - pattern: '^\s*enabled=[0,1]'
     - repl: 'enabled=1'
+{% endif %}
 {% endif %}
 
-{% if salt['pillar.get']('epel:testing', False) %}
-enable_epel_testing:
-  file.replace:
-    - name: /etc/yum.repos.d/epel-testing.repo
-    - pattern: '^enabled=[0,1]'
-    - repl: 'enabled=1'
-{% else %}
-disable_epel_testing:
-  file.replace:
-    - name: /etc/yum.repos.d/epel-testing.repo
-    - pattern: '^enabled=[0,1]'
-    - repl: 'enabled=0'
-{% endif %}
-{% endif %}

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -17,7 +17,7 @@
 {% elif grains['osmajorrelease'][0] == '7' %}
   {% set pkg = {
     'key': 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7',
-    'key_hash': 'md5=2d5d737d69703b926a2275e4c44a65e5',
+    'key_hash': 'md5=58fa8ae27c89f37b08429f04fd4a88cc',
     'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-' ~ epel_release|default('7-8', true) ~ '.noarch.rpm',
   } %}
 {% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] == '2014' %}

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -2,19 +2,19 @@
 {% if grains['os_family'] == 'RedHat' %}
   {% set epel_release = salt['pillar.get']('epel:release', false) %}
 # A lookup table for EPEL GPG keys & RPM URLs for various RedHat releases
-{% if grains['osmajorrelease'][0] == '5' %}
+{% if grains['osmajorrelease'] == 5 %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/A4D647E9.txt',
     'key_hash': 'md5=a1d12cd9628338ddb12e9561f9ac1d6a',
     'rpm': 'http://download.fedoraproject.org/pub/epel/5/i386/epel-release-' ~ epel_release|default('5-4', true) ~ '.noarch.rpm',
   } %}
-{% elif grains['osmajorrelease'][0] == '6' %}
+{% elif grains['osmajorrelease'] == 6 %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/0608B895.txt',
     'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
     'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-' ~ epel_release|default('6-8', true) ~ '.noarch.rpm',
   } %}
-{% elif grains['osmajorrelease'][0] == '7' %}
+{% elif grains['osmajorrelease'] == 7 %}
   {% set pkg = {
     'key': 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7',
     'key_hash': 'md5=58fa8ae27c89f37b08429f04fd4a88cc',

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -18,7 +18,7 @@
   {% set pkg = {
     'key': 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7',
     'key_hash': 'md5=58fa8ae27c89f37b08429f04fd4a88cc',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-' ~ epel_release|default('7-10', true) ~ '.noarch.rpm',
+    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-' ~ epel_release|default('7-11', true) ~ '.noarch.rpm',
   } %}
 {% elif grains['os'] == 'Amazon' and ( ( grains['saltversion'] >= '2017.7.0' and grains['osmajorrelease'] == 2014 ) or ( grains['saltversion'] < '2017.7.0' and grains['osmajorrelease'] == '2014' ) ) %}
   {% set pkg = {

--- a/epel/map.jinja
+++ b/epel/map.jinja
@@ -11,19 +11,19 @@
     },
     'RedHat': salt['grains.filter_by']({
       '5': {
-        'key': 'https://getfedora.org/static/A4D647E9.txt',
+        'key': 'https://fedoraproject.org/static/A4D647E9.txt',
         'key_hash': 'sha256=664c06f579d914f2cf25d05d4d581b8ddec77cae4f72f4020c3a9264b9d5ee71',
         'key_name': 'RPM-GPG-KEY-EPEL-5',
         'rpm': 'http://download.fedoraproject.org/pub/archive/epel/5/i386/epel-release-5-4.noarch.rpm',
       },
       '6': {
-        'key': 'https://getfedora.org/static/0608B895.txt',
+        'key': 'https://fedoraproject.org/static/0608B895.txt',
         'key_hash': 'sha256=16d35fa467c6efcee21d3aa068a02054b6a89a7a33bffa94db1fc141693d62a3',
         'key_name': 'RPM-GPG-KEY-EPEL-6',
         'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
       },
       '7': {
-        'key': 'https://getfedora.org/static/352C64E5.txt',
+        'key': 'https://fedoraproject.org/static/352C64E5.txt',
         'key_hash': 'sha256=22f25ad95d5e8d371760815485dba696ea3002fc2c7f812f2c75276853387107',
         'key_name': 'RPM-GPG-KEY-EPEL-7',
         'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-11.noarch.rpm',

--- a/epel/map.jinja
+++ b/epel/map.jinja
@@ -1,6 +1,7 @@
 {% set epel= salt['grains.filter_by'] ({
     'common':{
       'disabled': False,
+      'testing': False,
     },
     'Amazon': {
       'key': 'https://fedoraproject.org/static/0608B895.txt',

--- a/epel/map.jinja
+++ b/epel/map.jinja
@@ -1,0 +1,37 @@
+{% set epel= salt['grains.filter_by'] ({
+    'common':{
+      'disabled': False,
+    },
+    'Amazon': {
+      'key': 'https://fedoraproject.org/static/0608B895.txt',
+      'key_hash': 'sha256=16d35fa467c6efcee21d3aa068a02054b6a89a7a33bffa94db1fc141693d62a3',
+      'key_name': 'RPM-GPG-KEY-EPEL-6',
+      'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
+    },
+    'RedHat': salt['grains.filter_by']({
+      '5': {
+        'key': 'https://getfedora.org/static/A4D647E9.txt',
+        'key_hash': 'sha256=664c06f579d914f2cf25d05d4d581b8ddec77cae4f72f4020c3a9264b9d5ee71',
+        'key_name': 'RPM-GPG-KEY-EPEL-5',
+        'rpm': 'http://download.fedoraproject.org/pub/archive/epel/5/i386/epel-release-5-4.noarch.rpm',
+      },
+      '6': {
+        'key': 'https://getfedora.org/static/0608B895.txt',
+        'key_hash': 'sha256=16d35fa467c6efcee21d3aa068a02054b6a89a7a33bffa94db1fc141693d62a3',
+        'key_name': 'RPM-GPG-KEY-EPEL-6',
+        'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
+      },
+      '7': {
+        'key': 'https://getfedora.org/static/352C64E5.txt',
+        'key_hash': 'sha256=22f25ad95d5e8d371760815485dba696ea3002fc2c7f812f2c75276853387107',
+        'key_name': 'RPM-GPG-KEY-EPEL-7',
+        'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-11.noarch.rpm',
+      },
+    },
+    grain='osmajorrelease')
+  },
+  grain='os',
+  merge=salt['pillar.get']('epel:lookup'),
+  default='RedHat',
+  base='common' )
+-%}

--- a/pillar.example
+++ b/pillar.example
@@ -20,6 +20,9 @@ epel:
     repos:
       epel:
         enabled: true
+        exclude:
+          - pkg1
+          - pkg2
       epel-debuginfo:
         enabled: true
       epel-source:

--- a/pillar.example
+++ b/pillar.example
@@ -15,3 +15,18 @@ epel:
 
     # Disable (default)/enable EPEL testing
     testing: false
+
+    # Alternative, more detailed per-repo configuration
+    repos:
+      epel:
+        enabled: true
+      epel-debuginfo:
+        enabled: true
+      epel-source:
+        enabled: true
+      epel-testing:
+        enabled: false
+      epel-testing-debuginfo
+        enabled: false
+      epel-testing-source
+        enabled: false

--- a/pillar.example
+++ b/pillar.example
@@ -1,16 +1,14 @@
 epel:
-  # URL to the EPEL RPM to install
-  rpm: default varies with OS; see epel/init.sls
+  lookup:
+    # URL to the EPEL RPM to install
+    rpm: default varies with OS; see epel/init.sls
 
-  # URL to the EPEL GPG key
-  pubkey: default varies with OS; see epel/init.sls
-  pubkey_hash: default varies with OS; see epel/init.sls
+    # URL to the EPEL GPG key
+    pubkey: default varies with OS; see epel/map.jinja
+    pubkey_hash: default varies with OS; see epel/map.jinja
 
-  # Disable repo so requires the --enablerepo flag to use
-  disabled: false
+    # filename for the local EPEL Key
+    pubkey_name: default varies with OS; see epel/map.jinja
 
-  # Disable (default)/enable EPEL testing
-  testing: false
-
-  # Override the default EPEL release version
-  release: 7-8
+    # Disable repo so requires the --enablerepo flag to use
+    disabled: false

--- a/pillar.example
+++ b/pillar.example
@@ -8,3 +8,6 @@ epel:
 
   # Disable repo so requires the --enablerepo flag to use
   disabled: false
+
+  # Disable (default)/enable EPEL testing
+  testing: false

--- a/pillar.example
+++ b/pillar.example
@@ -12,3 +12,6 @@ epel:
 
     # Disable repo so requires the --enablerepo flag to use
     disabled: false
+
+    # Disable (default)/enable EPEL testing
+    testing: false

--- a/pillar.example
+++ b/pillar.example
@@ -11,3 +11,6 @@ epel:
 
   # Disable (default)/enable EPEL testing
   testing: false
+
+  # Override the default EPEL release version
+  release: 7-8


### PR DESCRIPTION
Upstream has changed map.jinja handling to set all Amazon linux OS grain targets to the same EPEL rpm, and then modify RHEL/CentOS variants only on the OS major version. We should incorporate this simpler method rather than incrementing Amazon OS 2017->2018 etc.